### PR TITLE
[Fix] oca-1481 Community Crypto version update

### DIFF
--- a/collections.yml
+++ b/collections.yml
@@ -1,6 +1,6 @@
 collections:
  - name: community.crypto
-   version: 2.15.1
+   version: 2.26.0
  - name: linode.cloud
    version: 0.16.1
  - name: gluster.gluster


### PR DESCRIPTION
Playbook was failing since community crypto version needed to be updated due to a change upstream

/tmp/linode/env/lib/python3.10/site-packages/paramiko/pkey.py:82: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleD
ES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "cipher": algorithms.TripleDES,
/tmp/linode/env/lib/python3.10/site-packages/paramiko/transport.py:253: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "class": algorithms.TripleDES,
  
  deployed a new cluster with new version and it worked as expected
  `PLAY RECAP *********************************************************************
172.232.15.64              : ok=35   changed=26   unreachable=0    failed=0     
172.234.25.197             : ok=35   changed=26   unreachable=0    failed=0     
localhost                  : ok=47   changed=32   unreachable=0    failed=0     

Running initial updates - This will take a while...
Installation complete!`